### PR TITLE
Fix: Use relative URL for JSON-RPC endpoint instead of absolute URL

### DIFF
--- a/VisualStatistics/Plugin.pm
+++ b/VisualStatistics/Plugin.pm
@@ -96,8 +96,7 @@ sub handleWeb {
 	$params->{'decadeselect'} = '';
 	$params->{'vlselect'} = '';
 
-	my $host = $params->{host} || (Slim::Utils::Network::serverAddr() . ':' . preferences('server')->get('httpport'));
-	$params->{'squeezebox_server_jsondatareq'} = 'http://' . $host . '/jsonrpc.js';
+	$params->{'squeezebox_server_jsondatareq'} = '/jsonrpc.js';
 
 	my $ratedTrackCountSQL = "select count(distinct tracks.id) from tracks,tracks_persistent where tracks_persistent.urlmd5 = tracks.urlmd5 and tracks.audio = 1 and tracks_persistent.rating > 0";
 	my $ratedTrackCount = quickSQLcount($ratedTrackCountSQL) || 0;


### PR DESCRIPTION
Current way of defining the JSON-RPC endpoint was not working in the case Lyrion is behind an url with https. Most of the plugin was working only changing the virtual library didn't had an impact.

Digging in the plugin code (with the help of a LLM), I found out that defining a relative URL (instead of the absolute one) works. Hence this PR.

I tested on my LMS and it works correctly, didn't see any side effect, but I can test more if needed.
